### PR TITLE
fix(schema):job-storeのrequestBodyのスキーマの整合性の修正

### DIFF
--- a/packages/schema/src/schema/headless-crawler/transformer.ts
+++ b/packages/schema/src/schema/headless-crawler/transformer.ts
@@ -4,7 +4,7 @@ import {
   RawReceivedDateShema,
   RawWageSchema,
   RawWorkingHoursSchema,
-} from "../headless-crawler";
+} from "./raw";
 
 const r = Symbol();
 export type TransformedReceivedDate = string & { [r]: unknown };

--- a/packages/schema/src/schema/job-store/index.ts
+++ b/packages/schema/src/schema/job-store/index.ts
@@ -1,2 +1,2 @@
 export * from "./jobInsert";
-export * from "./transformer";
+export * from "../headless-crawler/transformer";

--- a/packages/schema/src/schema/job-store/jobInsert.ts
+++ b/packages/schema/src/schema/job-store/jobInsert.ts
@@ -1,11 +1,7 @@
 import z from "zod";
 import { ScrapedJobSchema } from "../headless-crawler";
-import {
-  transformedEmployeeCountSchema,
-  transformedExpiryDateSchema,
-  transformedReceivedDateSchema,
-} from "./transformer";
-
+const ISO8601 =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[\+\-]\d{2}:\d{2})$/;
 export const insertJobRequestBodySchema = ScrapedJobSchema.omit({
   wage: true,
   receivedDate: true,
@@ -16,9 +12,9 @@ export const insertJobRequestBodySchema = ScrapedJobSchema.omit({
   wageMax: z.number(),
   workingStartTime: z.string(),
   workingEndTime: z.string(),
-  receivedDate: transformedReceivedDateSchema,
-  expiryDate: transformedExpiryDateSchema,
-  employeeCount: transformedEmployeeCountSchema,
+  receivedDate: z.string().regex(ISO8601),
+  expiryDate: z.string().regex(ISO8601),
+  employeeCount: z.number(),
 });
 
 export const insertJobResponseBodySchema = insertJobRequestBodySchema.extend({


### PR DESCRIPTION
- transform系をそのまま使うと、input前にheadless-cralwlerの方でtransformしてるので、整合性が取れない