### PR TITLE
feat(job-store):データ登録時、すでにデータが存在した時にクライアントエラーを返すように

### DIFF
--- a/packages/job-store/src/app.ts
+++ b/packages/job-store/src/app.ts
@@ -1,17 +1,6 @@
-import {
-  type InsertJobRequestBody,
-  insertJobClientErrorResponseSchema,
-  insertJobRequestBodySchema,
-  insertJobServerErrorResponseSchema,
-  insertJobSuccessResponseSchema,
-} from "@sho/schema";
-import { OpenAPIRoute, contentJson, fromHono } from "chanfana";
-import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { fromHono } from "chanfana";
 import { type Context, Hono } from "hono";
-import { HTTPException } from "hono/http-exception";
-import { ResultAsync } from "neverthrow";
-import { getDb } from "./db";
-import { jobs } from "./db/schema";
+import { JobInsertEndpoint } from "./endpoint/jobInsert";
 
 export type Env = {
   // Example bindings, use your own
@@ -19,56 +8,6 @@ export type Env = {
 };
 export type AppContext = Context<{ Bindings: Env }>;
 
-class JobInsertEndpoint extends OpenAPIRoute {
-  schema = {
-    request: {
-      body: {
-        ...contentJson(insertJobRequestBodySchema),
-      },
-    },
-    responses: {
-      "200": {
-        description: "Successful response",
-        ...contentJson(insertJobSuccessResponseSchema),
-      },
-      "400": {
-        description: "client error response",
-        ...contentJson(insertJobClientErrorResponseSchema),
-      },
-      "500": {
-        description: "internal server error response",
-        ...contentJson(insertJobServerErrorResponseSchema),
-      },
-    },
-  };
-
-  async handle(c: AppContext) {
-    const db = getDb(c);
-    const client = buildClient(db);
-    const result = ResultAsync.fromPromise(
-      this.getValidatedData<typeof this.schema>(),
-      (e) =>
-        ({
-          type: "ValidateError",
-          message: `schema validateion failed.\n${String(e)}`,
-        }) as const,
-    ).andThen(({ body }) => client.insertJob(body));
-    return result.match(
-      (job) => c.json({ success: true, result: { job } }, 200),
-      (e) => {
-        console.error(e);
-        switch (e.type) {
-          case "ValidateError":
-            throw new HTTPException(400, { message: "invalid req body" });
-          case "InsertJobError":
-            throw new HTTPException(500, { message: "internal server error" });
-          default:
-            throw new HTTPException(500, { message: "internal server error" });
-        }
-      },
-    );
-  }
-}
 const app = new Hono<{ Bindings: Env }>();
 
 // Initialize Chanfana for Hono
@@ -91,35 +30,5 @@ app.get("/", (c) => {
   return c.redirect("/api/v1/docs", 302); // 302 Found でリダイレクト
 });
 openapi.post("/api/v1/job", JobInsertEndpoint);
-
-const buildClient = (
-  db: DrizzleD1Database<Record<string, never>> & {
-    $client: D1Database;
-  },
-) => {
-  return {
-    insertJob: (job: InsertJobRequestBody) => {
-      const now = new Date();
-      const insertingValues = {
-        ...job,
-        createdAt: now.toISOString(),
-        updatedAt: now.toISOString(),
-        status: "active",
-      };
-      console.log(
-        `inserting values.\nvalues=${JSON.stringify(insertingValues, null, 2)}`,
-      );
-      return ResultAsync.fromPromise(
-        db.insert(jobs).values(insertingValues),
-        (e) => {
-          return {
-            type: "InsertJobError",
-            message: `insert job failed.\n${String(e)}`,
-          } as const;
-        },
-      ).map(() => insertingValues);
-    },
-  };
-};
 
 export { app };

--- a/packages/job-store/src/endpoint/jobInsert.ts
+++ b/packages/job-store/src/endpoint/jobInsert.ts
@@ -1,0 +1,130 @@
+import {
+  type InsertJobRequestBody,
+  insertJobClientErrorResponseSchema,
+  insertJobRequestBodySchema,
+  insertJobServerErrorResponseSchema,
+  insertJobSuccessResponseSchema,
+} from "@sho/schema";
+import { OpenAPIRoute, contentJson } from "chanfana";
+import { eq } from "drizzle-orm";
+import type { DrizzleD1Database } from "drizzle-orm/d1";
+import { HTTPException } from "hono/http-exception";
+import { ResultAsync, err, ok } from "neverthrow";
+import type { AppContext } from "../app";
+import { getDb } from "../db";
+import { jobs } from "../db/schema";
+
+export class JobInsertEndpoint extends OpenAPIRoute {
+  schema = {
+    request: {
+      body: {
+        ...contentJson(insertJobRequestBodySchema),
+      },
+    },
+    responses: {
+      "200": {
+        description: "Successful response",
+        ...contentJson(insertJobSuccessResponseSchema),
+      },
+      "400": {
+        description: "client error response",
+        ...contentJson(insertJobClientErrorResponseSchema),
+      },
+      "500": {
+        description: "internal server error response",
+        ...contentJson(insertJobServerErrorResponseSchema),
+      },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const db = getDb(c);
+    const client = new D1Client(db);
+    const result = ResultAsync.fromPromise(
+      this.getValidatedData<typeof this.schema>(),
+      (e) =>
+        ({
+          type: "ValidateError",
+          message: `schema validateion failed.\n${String(e)}`,
+        }) as const,
+    ).andThen(({ body }) => client.insertJob(body));
+    return result.match(
+      (job) => c.json({ success: true, result: { job } }, 200),
+      (e) => {
+        console.error(e);
+        switch (e.type) {
+          case "ValidateError":
+            throw new HTTPException(400, { message: "invalid req body" });
+          case "DuplicateJobError":
+            throw new HTTPException(400, {
+              message: `duplicate jobNumber: ${jobs.jobNumber}`,
+            });
+          case "InsertJobError":
+            throw new HTTPException(500, { message: "internal server error" });
+          default:
+            throw new HTTPException(500, { message: "internal server error" });
+        }
+      },
+    );
+  }
+}
+
+class D1Client {
+  private db: DrizzleD1Database<Record<string, never>> & {
+    $client: D1Database;
+  };
+
+  constructor(
+    db: DrizzleD1Database<Record<string, never>> & {
+      $client: D1Database;
+    },
+  ) {
+    this.db = db;
+  }
+
+  insertJob(job: InsertJobRequestBody) {
+    return this.checkDuplicate(job.jobNumber)
+      .andThen((duplicated) => {
+        if (duplicated) {
+          return err({
+            type: "DuplicateJobError" as const,
+            message: `job duplicated. jobNumber=${job.jobNumber}}`,
+          });
+        }
+        return ok(job);
+      })
+      .andThen((job) => {
+        const now = new Date();
+        const insertingValues = {
+          ...job,
+          createdAt: now.toISOString(),
+          updatedAt: now.toISOString(),
+          status: "active",
+        };
+
+        console.log(
+          `inserting values.\nvalues=${JSON.stringify(insertingValues, null, 2)}`,
+        );
+        this.db.insert(jobs).values(insertingValues);
+        return ResultAsync.fromPromise(
+          this.db.insert(jobs).values(insertingValues),
+          (e) => {
+            return {
+              type: "InsertJobError",
+              message: `insert job failed.\n${String(e)}`,
+            } as const;
+          },
+        );
+      });
+  }
+
+  checkDuplicate(jobNumber: string) {
+    return ResultAsync.fromPromise(
+      this.db.select().from(jobs).where(eq(jobs.jobNumber, jobNumber)).limit(1),
+      (e) => ({
+        type: "SelectJobError" as const,
+        message: `select job failed. jobNumber=${jobNumber}\n${String(e)}`,
+      }),
+    ).map((rows) => rows.length !== 0);
+  }
+}


### PR DESCRIPTION
- 見通しを良くするためにファイルをエンドポイントとアプリに分けた
- jobInsetの中の処理が汚いが、一旦後で