### PR TITLE
feat(job-store):事前にバンドルするように

### DIFF
--- a/packages/job-store/package.json
+++ b/packages/job-store/package.json
@@ -3,7 +3,8 @@
 	"version": "0.0.0",
 	"private": true,
 	"scripts": {
-		"deploy": "wrangler deploy",
+		"deploy": "pnpm build && wrangler deploy",
+		"build": "tsup",
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
 		"test": "vitest",
@@ -13,6 +14,7 @@
 		"@cloudflare/vitest-pool-workers": "^0.8.19",
 		"@types/node": "^24.0.15",
 		"drizzle-kit": "^0.31.4",
+		"tsup": "^8.5.0",
 		"tsx": "^4.20.3",
 		"typescript": "^5.5.2",
 		"vitest": "~3.2.0",
@@ -21,6 +23,7 @@
 	"dependencies": {
 		"@hono/zod-openapi": "^1.0.2",
 		"@hono/zod-validator": "^0.7.2",
+		"@sho/schema": "workspace:*",
 		"chanfana": "^2.8.1",
 		"dotenv": "^17.0.0",
 		"drizzle-orm": "^0.44.2",
@@ -28,7 +31,6 @@
 		"hono-openapi": "^0.4.8",
 		"neverthrow": "^8.2.0",
 		"valibot": "^1.1.0",
-		"zod": "~3.25.74",
-		"@sho/schema": "workspace:*"
+		"zod": "~3.25.74"
 	}
 }

--- a/packages/job-store/tsup.config.ts
+++ b/packages/job-store/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  outDir: "dist",
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  format: ["esm"],
+  noExternal: ["@sho/schema"],
+  target: "es2022",
+});

--- a/packages/job-store/wrangler.jsonc
+++ b/packages/job-store/wrangler.jsonc
@@ -5,7 +5,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "job-store",
-  "main": "src/index.ts",
+  "main": "dist/index.mjs",
   "compatibility_date": "2025-07-19",
   "observability": {
     "enabled": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       drizzle-kit:
         specifier: ^0.31.4
         version: 0.31.4
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.0(postcss@8.5.6)(tsx@4.20.3)(typescript@5.8.3)(yaml@2.8.0)
       tsx:
         specifier: ^4.20.3
         version: 4.20.3


### PR DESCRIPTION
- job-storeからschemaのAPIを利用しようとするとimport Errorが出てしまうので、事前にバンドルしたものをデプロイすることに