### PR TITLE
feat: JWTベースのページネーション機能付きjob listエンドポイントを追加

### DIFF
--- a/packages/job-store/src/client/error.ts
+++ b/packages/job-store/src/client/error.ts
@@ -7,3 +7,6 @@ export class JobNotFoundError extends Data.TaggedError("JobNotFoundError")<{
 export class FetchJobError extends Data.TaggedError("FetchJobError")<{
   message: string;
 }> {}
+export class FetchJobListError extends Data.TaggedError("FetchJobListError")<{
+  message: string;
+}> {}

--- a/packages/job-store/src/client/index.ts
+++ b/packages/job-store/src/client/index.ts
@@ -7,7 +7,7 @@ import {
   InsertJobDuplicationError,
   InsertJobError,
 } from "../endpoint/jobInsert/error";
-import { FetchJobError, JobNotFoundError } from "./error";
+import { FetchJobError, FetchJobListError, JobNotFoundError } from "./error";
 
 export class JobStoreClient extends Context.Tag("JobStoreClient")<
   JobStoreClient,
@@ -24,6 +24,16 @@ export class JobStoreClient extends Context.Tag("JobStoreClient")<
     readonly fetchJob: (
       jobNumber: string,
     ) => Effect.Effect<Job, FetchJobError | JobNotFoundError>;
+    readonly fetchJobList: ({
+      cursor,
+      limit,
+    }: {
+      cursor?: { jobId: number };
+      limit: number;
+    }) => Effect.Effect<
+      { jobs: Job[]; cursor: { jobId: number } },
+      FetchJobListError
+    >;
   }
 >() {}
 
@@ -84,6 +94,31 @@ function buildJobStoreClientLive(
             );
           }
           return Effect.succeed(rows[0]);
+        }),
+      ),
+    fetchJobList: ({
+      limit = 20,
+      cursor,
+    }: { cursor?: { jobId: number }; limit: number }) =>
+      Effect.tryPromise({
+        try: () =>
+          cursor
+            ? db
+                .select()
+                .from(jobs)
+                .where(eq(jobs.id, cursor.jobId))
+                .limit(limit)
+            : db.select().from(jobs).limit(limit),
+        catch: (e) =>
+          new FetchJobListError({
+            message: `fetch job list failed.\n${String(e)}`,
+          }),
+      }).pipe(
+        Effect.map((jobs) => {
+          return {
+            jobs: jobs,
+            cursor: { jobId: jobs.length > 0 ? jobs[jobs.length - 1].id : 1 },
+          };
         }),
       ),
   });

--- a/packages/job-store/src/client/index.ts
+++ b/packages/job-store/src/client/index.ts
@@ -106,7 +106,7 @@ function buildJobStoreClientLive(
             ? db
                 .select()
                 .from(jobs)
-                .where(eq(jobs.id, cursor.jobId))
+                .where(gt(jobs.id, cursor.jobId))
                 .limit(limit)
             : db.select().from(jobs).limit(limit),
         catch: (e) =>

--- a/packages/job-store/src/endpoint/jobList/error.ts
+++ b/packages/job-store/src/endpoint/jobList/error.ts
@@ -1,0 +1,19 @@
+import { Data } from "effect";
+export class GetJWTSecretError extends Data.TaggedError("GetJWTSecretError")<{
+  message: string;
+}> {}
+export class FetchJobListValidationError extends Data.TaggedError(
+  "FetchJobListValidationError",
+)<{ message: string }> {}
+export class JWTSignatureError extends Data.TaggedError("JWTSignatureError")<{
+  message: string;
+}> {}
+export class JWTDecodeError extends Data.TaggedError("JWTDecodeError")<{
+  message: string;
+}> {}
+export class JWTExpiredError extends Data.TaggedError("JWTExpiredError")<{
+  message: string;
+}> {}
+export class DecodeJWTPayloadError extends Data.TaggedError(
+  "DecodeJWTPayloadError",
+)<{ message: string }> {}

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -152,7 +152,7 @@ export class JobListEndpoint extends OpenAPIRoute {
           throw new HTTPException(500, { message: "internal server error" });
         }
         if (error instanceof JWTExpiredError) {
-          throw new HTTPException(500, { message: "internal server error" });
+          throw new HTTPException(400, { message: "token expired" });
         }
         throw new HTTPException(500, { message: "internal server error" });
       },

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -1,0 +1,164 @@
+import {
+  decodedNextTokenSchema,
+  jobListClientErrorResponseSchema,
+  jobListQuerySchema,
+  jobListServerErrorSchema,
+  jobListSuccessResponseSchema,
+} from "@sho/models";
+import { OpenAPIRoute, contentJson } from "chanfana";
+import { Effect, Exit } from "effect";
+import { HTTPException } from "hono/http-exception";
+import { decode, sign } from "hono/jwt";
+import type { AppContext } from "../../app";
+import { JobStoreClient, makeJobStoreClientLayer } from "../../client";
+import { FetchJobListError } from "../../client/error";
+import { getDb } from "../../db";
+import {
+  DecodeJWTPayloadError,
+  GetJWTSecretError,
+  JWTDecodeError,
+  JWTExpiredError,
+  JWTSignatureError,
+} from "./error";
+
+const j = Symbol();
+type JWTSecret = string & { j: unknown };
+
+export class JobListEndpoint extends OpenAPIRoute {
+  schema = {
+    request: {
+      query: jobListQuerySchema,
+    },
+    responses: {
+      "200": {
+        description: "Successful response",
+        ...contentJson(jobListSuccessResponseSchema),
+      },
+      "400": {
+        description: "client error response",
+        ...contentJson(jobListClientErrorResponseSchema),
+      },
+      "500": {
+        description: "internal server error response",
+        ...contentJson(jobListServerErrorSchema),
+      },
+    },
+  };
+
+  async handle(c: AppContext) {
+    const db = getDb(c);
+    // Effect内でthisを使用したいため
+    const self = this;
+    const program = Effect.gen(function* () {
+      const jobStoreClient = yield* JobStoreClient;
+      // jwtを使ってnextToken作る
+      const jwtSecret = yield* (() => {
+        const secret = process.env.JWT_SECRET;
+        if (!secret)
+          return Effect.fail(
+            new GetJWTSecretError({ message: "gettting jwt secret failed" }),
+          );
+        return Effect.succeed(secret as JWTSecret);
+      })();
+
+      const nextTokenOrNot = yield* Effect.tryPromise({
+        try: () => self.getValidatedData<typeof self.schema>(),
+        catch: (e) =>
+          new FetchJobListError({ message: "Fetch JobList validation failed" }),
+      }).pipe(Effect.map(({ query }) => query.nextToken));
+
+      // ここ、どうしてもいい処理が思いつかないので一旦汚く
+      if (!nextTokenOrNot) {
+        const {
+          jobs,
+          cursor: { jobId },
+        } = yield* jobStoreClient.fetchJobList({
+          cursor: { jobId: 1 },
+          limit: 20,
+        });
+        const signed = yield* Effect.tryPromise({
+          try: () =>
+            sign(
+              {
+                exp: Math.floor(Date.now() / 1000) + 60 * 15,
+                cursor: { jobId },
+              },
+              jwtSecret,
+            ),
+          catch: (e) =>
+            new JWTSignatureError({
+              message: `JWT signing failed.\n${String(e)}`,
+            }),
+        });
+        return { jobs, nextToken: signed };
+      }
+      const nextToken = nextTokenOrNot;
+      const { payload } = yield* Effect.try({
+        try: () => decode(nextToken),
+        catch: (e) =>
+          new JWTDecodeError({ message: `JWT decoding failed.\n${String(e)}` }),
+      });
+      const validatedPayload = (() => {
+        const result = decodedNextTokenSchema.safeParse(payload);
+        if (!result.success)
+          throw new DecodeJWTPayloadError({
+            message: `Decoding JWT payload failed.\n${String(result.error)}`,
+          });
+        return result.data;
+      })();
+      const now = Math.floor(Date.now() / 1000);
+      if (validatedPayload.exp && validatedPayload.exp < now)
+        return new JWTExpiredError({ message: "JWT expired" });
+      const jobListData = yield* jobStoreClient.fetchJobList({
+        cursor: { jobId: validatedPayload.cursor.jobId },
+        limit: 20,
+      });
+      const signed = yield* Effect.tryPromise({
+        try: () =>
+          sign(
+            {
+              exp: Math.floor(Date.now() / 1000) + 60 * 15,
+              cursor: { jobId: jobListData.cursor.jobId },
+            },
+            jwtSecret,
+          ),
+        catch: (e) =>
+          new JWTSignatureError({
+            message: `JWT signing failed.\n${String(e)}`,
+          }),
+      });
+      return { jobs: jobListData.jobs, nextToken: signed };
+    });
+    const runnable = Effect.provide(program, makeJobStoreClientLayer(db));
+
+    const exit = await Effect.runPromiseExit(runnable);
+
+    return Exit.match(exit, {
+      onFailure: (error) => {
+        // そのうちここ綺麗にしたい
+        if (error instanceof FetchJobListError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        if (error instanceof GetJWTSecretError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        if (error instanceof JWTSignatureError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        if (error instanceof JWTDecodeError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        if (error instanceof DecodeJWTPayloadError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        if (error instanceof JWTExpiredError) {
+          throw new HTTPException(500, { message: "internal server error" });
+        }
+        throw new HTTPException(500, { message: "internal server error" });
+      },
+      onSuccess: (data) => {
+        return c.json(data);
+      },
+    });
+  }
+}

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -149,7 +149,7 @@ export class JobListEndpoint extends OpenAPIRoute {
           throw new HTTPException(400, { message: "invalid JWT token" });
         }
         if (error instanceof DecodeJWTPayloadError) {
-          throw new HTTPException(500, { message: "internal server error" });
+          throw new HTTPException(400, { message: "malformed JWT payload" });
         }
         if (error instanceof JWTExpiredError) {
           throw new HTTPException(400, { message: "token expired" });

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -56,7 +56,7 @@ export class JobListEndpoint extends OpenAPIRoute {
         const secret = process.env.JWT_SECRET;
         if (!secret)
           return Effect.fail(
-            new GetJWTSecretError({ message: "gettting jwt secret failed" }),
+            new GetJWTSecretError({ message: "getting jwt secret failed" }),
           );
         return Effect.succeed(secret as JWTSecret);
       })();

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -108,7 +108,7 @@ export class JobListEndpoint extends OpenAPIRoute {
       })();
       const now = Math.floor(Date.now() / 1000);
       if (validatedPayload.exp && validatedPayload.exp < now)
-        return new JWTExpiredError({ message: "JWT expired" });
+        return Effect.fail(new JWTExpiredError({ message: "JWT expired" }));
       const jobListData = yield* jobStoreClient.fetchJobList({
         cursor: { jobId: validatedPayload.cursor.jobId },
         limit: 20,

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -73,7 +73,7 @@ export class JobListEndpoint extends OpenAPIRoute {
           jobs,
           cursor: { jobId },
         } = yield* jobStoreClient.fetchJobList({
-          cursor: { jobId: 1 },
+          cursor: { jobId: INITIAL_JOB_ID },
           limit: 20,
         });
         const signed = yield* Effect.tryPromise({

--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -146,7 +146,7 @@ export class JobListEndpoint extends OpenAPIRoute {
           throw new HTTPException(500, { message: "internal server error" });
         }
         if (error instanceof JWTDecodeError) {
-          throw new HTTPException(500, { message: "internal server error" });
+          throw new HTTPException(400, { message: "invalid JWT token" });
         }
         if (error instanceof DecodeJWTPayloadError) {
           throw new HTTPException(500, { message: "internal server error" });

--- a/packages/models/src/schemas/job-store/jobList.ts
+++ b/packages/models/src/schemas/job-store/jobList.ts
@@ -5,6 +5,13 @@ export const jobListQuerySchema = z.object({
   nextToken: z.string().optional(),
 });
 
+export const decodedNextTokenSchema = z.object({
+  exp: z.number(),
+  cursor: z.object({
+    jobId: z.number(),
+  }),
+});
+
 export const JobListSchema = z.array(
   jobSelectSchema.omit({
     id: true,


### PR DESCRIPTION
- OpenAPIスキーマ定義を含むJobListEndpointクラスを追加
- カーソルページネーション用のJWTベースnextTokenを実装
- JWT操作の包括的なエラーハンドリングを追加
- クライアントエラー処理用のFetchJobListErrorを作成
- job list API用のクエリとレスポンススキーマを追加
- 1ページ20件、トークン有効期限15分のページネーションをサポート