### PR TITLE
refactor(hello-work-job-searcher): 求人情報取得のコンポーネントとフックのインターフェースの変更

### DIFF
--- a/apps/hello-work-job-searcher/src/app/client/components/JobOverViewList/index.tsx
+++ b/apps/hello-work-job-searcher/src/app/client/components/JobOverViewList/index.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import type { TJobOverview } from "@sho/models";
 import { useVirtualizer, type VirtualItem } from "@tanstack/react-virtual";
 import Link from "next/link";
 import React, { useEffect } from "react";
@@ -11,18 +10,9 @@ import styles from "./JobOverviewList.module.css";
 let _kSavedOffset = 0;
 let _kMeasurementsCache = [] as VirtualItem[];
 
-export function JobOverviewList({
-  initialItems,
-  nextToken,
-}: {
-  initialItems: TJobOverview[];
-  nextToken?: string;
-}) {
+export function JobOverviewList() {
   const { items, fetchNextPage, isFetchingNextPage, hasNextPage } =
-    useInfiniteJobList({
-      initialItems,
-      nextToken,
-    });
+    useInfiniteJobList();
 
   const parentRef = React.useRef<HTMLDivElement>(null);
 

--- a/apps/hello-work-job-searcher/src/app/client/components/JobsPageClient.tsx
+++ b/apps/hello-work-job-searcher/src/app/client/components/JobsPageClient.tsx
@@ -1,0 +1,18 @@
+// JobsPageClient.tsx (新規作成) - Client Component
+"use client";
+
+import { type DehydratedState, HydrationBoundary } from "@tanstack/react-query";
+
+interface JobsPageClientProps {
+  dehydratedState: DehydratedState;
+  children: React.ReactNode;
+}
+
+export function JobsPageClient({
+  dehydratedState,
+  children,
+}: JobsPageClientProps) {
+  return (
+    <HydrationBoundary state={dehydratedState}>{children}</HydrationBoundary>
+  );
+}

--- a/apps/hello-work-job-searcher/src/app/client/hooks/useInfiniteJobList.ts
+++ b/apps/hello-work-job-searcher/src/app/client/hooks/useInfiniteJobList.ts
@@ -17,30 +17,22 @@ async function fetchServerPage(nextToken?: string) {
   return { items: nextItems, nextToken: validatedData.nextToken };
 }
 
-export const useInfiniteJobList = ({
-  initialItems,
-  nextToken,
-}: {
-  initialItems: TJobOverview[];
-  nextToken?: string;
-}) => {
-  const { data, fetchNextPage, isFetchingNextPage, hasNextPage } =
+export const useInfiniteJobList = () => {
+  const { data, fetchNextPage, isFetchingNextPage, hasNextPage, isLoading } =
     useInfiniteQuery({
       queryKey: ["jobs"],
-      queryFn: (ctx) => fetchServerPage(ctx.pageParam),
-      initialData: {
-        pages: [{ items: initialItems, nextToken }],
-        pageParams: [nextToken],
-      },
+      queryFn: (ctx) => fetchServerPage(ctx.pageParam), // pageParamは string | undefined
       getNextPageParam: (lastGroup) => lastGroup.nextToken,
-      initialPageParam: nextToken,
+      initialPageParam: undefined as string | undefined, // 型を明示的に指定
+      staleTime: 1000 * 60 * 5,
     });
 
   return {
-    items: data.pages.flatMap((page) => page.items),
-    nextToken: data.pages[data.pages.length - 1].nextToken,
+    items: data?.pages.flatMap((page) => page.items) || [],
+    nextToken: data?.pages[data.pages.length - 1]?.nextToken,
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
+    isLoading,
   };
 };

--- a/apps/hello-work-job-searcher/src/app/jobs/page.tsx
+++ b/apps/hello-work-job-searcher/src/app/jobs/page.tsx
@@ -1,8 +1,10 @@
 export const dynamic = "force-dynamic";
 
 import type { TJobOverview } from "@sho/models";
+import { dehydrate, QueryClient } from "@tanstack/react-query";
 import { jobStoreClient } from "../client";
 import { JobOverviewList } from "../client/components/JobOverViewList";
+import { JobsPageClient } from "../client/components/JobsPageClient";
 import { FlexColumn, FlexN } from "../components";
 
 export default async function Page() {
@@ -15,19 +17,29 @@ export default async function Page() {
     employmentType: job.employmentType,
     workPlace: job.workPlace || "不明",
   }));
+
+  const queryClient = new QueryClient(); // QueryClientに初期データをプリロード
+  queryClient.setQueryData(["jobs"], {
+    pages: [
+      {
+        items: initialItems,
+        nextToken: data.nextToken,
+      },
+    ],
+    pageParams: [data.nextToken],
+  });
   return (
-    <main style={{ height: "100%" }}>
-      <FlexColumn>
-        <FlexN n={1}>
-          <h1>求人情報一覧</h1>
-        </FlexN>
-        <FlexN n={9}>
-          <JobOverviewList
-            initialItems={initialItems}
-            nextToken={data.nextToken}
-          />
-        </FlexN>
-      </FlexColumn>
-    </main>
+    <JobsPageClient dehydratedState={dehydrate(queryClient)}>
+      <main style={{ height: "100%" }}>
+        <FlexColumn>
+          <FlexN n={1}>
+            <h1>求人情報一覧</h1>
+          </FlexN>
+          <FlexN n={9}>
+            <JobOverviewList />
+          </FlexN>
+        </FlexColumn>
+      </main>
+    </JobsPageClient>
   );
 }


### PR DESCRIPTION
- initialItemsがインターフェースに生えてるのがちょっと嫌だった
- queryClientで、事前データを取得することで、RSCを生かす構成に