### PR TITLE
fix(job-store): エンコードされたクエリの対応

### DIFF
--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -57,8 +57,12 @@ export class JobListEndpoint extends OpenAPIRoute {
       );
 
       const {
-        query: { nextToken, companyName },
+        query: { nextToken, companyName: encodedCompanyName },
       } = validatedData;
+
+      const companyName = encodedCompanyName
+        ? decodeURIComponent(encodedCompanyName)
+        : undefined;
       const jwtSecret = c.env.JWT_SECRET;
 
       // JobStoreClientの作成


### PR DESCRIPTION
- フロントエンドで、エンコードされて、companyNameが送信されるため