### PR TITLE
fix(job-store): 求人情報取得APIの修正

### DIFF
--- a/packages/job-store/src/endpoint/jobList/jobList.ts
+++ b/packages/job-store/src/endpoint/jobList/jobList.ts
@@ -129,6 +129,9 @@ export class JobListEndpoint extends OpenAPIRoute {
       const jobListResult = yield* await jobStore.fetchJobList({
         cursor: { jobId: validatedPayload.cursor.jobId },
         limit: 20,
+        filter: {
+          companyName,
+        },
       });
 
       const {


### PR DESCRIPTION
- 2回目以降で、companyNameが入ってなかった