### PR TITLE
refactor: job-storeクライアントをコマンドパターンに変更

### DIFF
--- a/packages/job-store/src/clientImpl/adapter.ts
+++ b/packages/job-store/src/clientImpl/adapter.ts
@@ -1,8 +1,11 @@
 import type {
-  InsertJobRequestBody,
-  Job,
+  CheckJobExistsCommand,
+  CommandOutput,
+  FindJobByNumberCommand,
+  FindJobsCommand,
+  InsertJobCommand,
+  JobStoreCommand,
   JobStoreDBClient,
-  SearchFilter,
 } from "@sho/models";
 import { and, eq, gt, like } from "drizzle-orm";
 import type { DrizzleD1Database } from "drizzle-orm/d1";
@@ -12,84 +15,124 @@ type DrizzleD1Client = DrizzleD1Database<Record<string, never>> & {
   $client: D1Database;
 };
 
+// --- コマンドごとの処理 ---
+async function handleInsertJob(
+  drizzle: DrizzleD1Client,
+  cmd: InsertJobCommand,
+): Promise<CommandOutput<InsertJobCommand>> {
+  const now = new Date();
+  const insertingValues = {
+    ...cmd.payload,
+    createdAt: now.toISOString(),
+    updatedAt: now.toISOString(),
+    status: "active" as const,
+  };
+  const result = await drizzle.insert(jobs).values(insertingValues);
+  const jobId =
+    (result && "lastInsertRowid" in result
+      ? Number(result.lastInsertRowid)
+      : undefined) ?? 1;
+  return { jobId };
+}
+
+async function handleFindJobByNumber(
+  drizzle: DrizzleD1Client,
+  cmd: FindJobByNumberCommand,
+): Promise<CommandOutput<FindJobByNumberCommand>> {
+  const rows = await drizzle
+    .select()
+    .from(jobs)
+    .where(eq(jobs.jobNumber, cmd.jobNumber))
+    .limit(1);
+  return { job: rows.length > 0 ? rows[0] : null };
+}
+
+async function handleFindJobs(
+  drizzle: DrizzleD1Client,
+  cmd: FindJobsCommand,
+): Promise<CommandOutput<FindJobsCommand>> {
+  const { cursor, limit, filter = {} } = cmd.options;
+
+  const cursorConditions = [];
+  if (cursor) {
+    cursorConditions.push(gt(jobs.id, cursor.jobId));
+  }
+
+  const filterConditions = [];
+  if (filter.companyName) {
+    filterConditions.push(like(jobs.companyName, `%${filter.companyName}%`));
+  }
+
+  const conditions = [...cursorConditions, ...filterConditions];
+  const query = drizzle.select().from(jobs);
+
+  const jobList =
+    conditions.length > 0
+      ? await query.where(and(...conditions)).limit(limit)
+      : await query.limit(limit);
+
+  // 仮のtotalCount取得
+  const totalCount = await drizzle.$count(
+    jobs,
+    filterConditions.length > 0 ? and(...filterConditions) : undefined,
+  );
+
+  return {
+    jobs: jobList,
+    cursor: {
+      jobId: jobList.length > 0 ? jobList[jobList.length - 1].id : 1,
+    },
+    meta: {
+      totalCount,
+      filter,
+    },
+  };
+}
+
+async function handleCheckJobExists(
+  drizzle: DrizzleD1Client,
+  cmd: CheckJobExistsCommand,
+): Promise<CommandOutput<CheckJobExistsCommand>> {
+  const rows = await drizzle
+    .select()
+    .from(jobs)
+    .where(eq(jobs.jobNumber, cmd.jobNumber))
+    .limit(1);
+  return { exists: rows.length > 0 };
+}
+
+// --- アダプタ本体 ---
 export const createJobStoreDBClientAdapter = (
   drizzleClient: DrizzleD1Client,
 ): JobStoreDBClient => ({
-  insertJob: async (
-    job: InsertJobRequestBody,
-  ): Promise<InsertJobRequestBody> => {
-    const now = new Date();
-    const insertingValues = {
-      ...job,
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-      status: "active" as const,
-    };
-    await drizzleClient.insert(jobs).values(insertingValues);
-    return job;
-  },
-
-  findJobByNumber: async (jobNumber: string): Promise<Job | null> => {
-    const rows = await drizzleClient
-      .select()
-      .from(jobs)
-      .where(eq(jobs.jobNumber, jobNumber))
-      .limit(1);
-    return rows.length > 0 ? rows[0] : null;
-  },
-
-  findJobs: async (options: {
-    cursor?: { jobId: number };
-    limit: number;
-    filter: { companyName?: string };
-  }): Promise<{
-    jobs: Job[];
-    cursor: { jobId: number };
-    meta: { totalCount: number; filter: SearchFilter };
-  }> => {
-    const { cursor, limit, filter = {} } = options;
-
-    const cursorConditions = [];
-    if (cursor) {
-      cursorConditions.push(gt(jobs.id, cursor.jobId));
+  execute: async <T extends JobStoreCommand>(
+    cmd: T,
+  ): Promise<CommandOutput<T>> => {
+    switch (cmd.type) {
+      case "InsertJob":
+        return (await handleInsertJob(
+          drizzleClient,
+          cmd as InsertJobCommand,
+        )) as CommandOutput<T>;
+      case "FindJobByNumber":
+        return (await handleFindJobByNumber(
+          drizzleClient,
+          cmd as FindJobByNumberCommand,
+        )) as CommandOutput<T>;
+      case "FindJobs":
+        return (await handleFindJobs(
+          drizzleClient,
+          cmd as FindJobsCommand,
+        )) as CommandOutput<T>;
+      case "CheckJobExists":
+        return (await handleCheckJobExists(
+          drizzleClient,
+          cmd as CheckJobExistsCommand,
+        )) as CommandOutput<T>;
+      default: {
+        const _exhaustive: never = cmd;
+        throw new Error("Unknown command type");
+      }
     }
-
-    const filterConditions = [];
-    if (filter.companyName) {
-      filterConditions.push(like(jobs.companyName, `%${filter.companyName}%`));
-    }
-
-    const conditions = [...cursorConditions, ...filterConditions];
-    const query = drizzleClient.select().from(jobs);
-
-    const jobList =
-      conditions.length > 0
-        ? await query.where(and(...conditions)).limit(limit)
-        : await query.limit(limit);
-
-    const totalCount = await drizzleClient.$count(
-      jobs,
-      filterConditions.length > 0 ? and(...filterConditions) : undefined,
-    );
-
-    return {
-      jobs: jobList,
-      cursor: {
-        jobId: jobList.length > 0 ? jobList[jobList.length - 1].id : 1,
-      },
-      meta: {
-        totalCount,
-        filter,
-      },
-    };
-  },
-
-  checkJobExists: async (jobNumber: string): Promise<boolean> => {
-    const rows = await drizzleClient
-      .select()
-      .from(jobs)
-      .where(eq(jobs.jobNumber, jobNumber))
-      .limit(1);
-    return rows.length > 0;
   },
 });

--- a/packages/job-store/src/clientImpl/type.ts
+++ b/packages/job-store/src/clientImpl/type.ts
@@ -1,6 +1,10 @@
 import type {
+  CheckJobExistsCommand,
+  CommandOutput,
+  FindJobByNumberCommand,
+  FindJobsCommand,
+  InsertJobCommand,
   InsertJobRequestBody,
-  Job,
   JobStoreDBClient,
   SearchFilter,
 } from "@sho/models";
@@ -17,25 +21,24 @@ export type JobStoreResultBuilder = (client: JobStoreDBClient) => {
   insertJob: (
     job: InsertJobRequestBody,
   ) => ResultAsync<
-    InsertJobRequestBody,
+    CommandOutput<InsertJobCommand>,
     InsertJobDuplicationError | InsertJobError
   >;
   fetchJob: (
     jobNumber: string,
-  ) => ResultAsync<Job, FetchJobError | JobNotFoundError>;
+  ) => ResultAsync<
+    CommandOutput<FindJobByNumberCommand>["job"],
+    FetchJobError | JobNotFoundError
+  >;
   checkDuplicate: (
     jobNumber: string,
-  ) => ResultAsync<boolean, InsertJobDuplicationError>;
+  ) => ResultAsync<
+    CommandOutput<CheckJobExistsCommand>["exists"],
+    InsertJobDuplicationError
+  >;
   fetchJobList: (params: {
     cursor?: { jobId: number };
     limit: number;
-    filter: { companyName?: string };
-  }) => ResultAsync<
-    {
-      jobs: Job[];
-      cursor: { jobId: number };
-      meta: { totalCount: number; filter: SearchFilter };
-    },
-    FetchJobListError
-  >;
+    filter: SearchFilter;
+  }) => ResultAsync<CommandOutput<FindJobsCommand>, FetchJobListError>;
 };

--- a/packages/models/src/types/job-store/client.ts
+++ b/packages/models/src/types/job-store/client.ts
@@ -1,19 +1,57 @@
 import type { Job } from "./jobFetch";
 import type { InsertJobRequestBody } from "./jobInsert";
 
-export type SearchFilter = { companyName?: string };
-
-export type JobStoreDBClient = {
-  insertJob: (job: InsertJobRequestBody) => Promise<InsertJobRequestBody>;
-  findJobByNumber: (jobNumber: string) => Promise<Job | null>;
-  findJobs: (options: {
+// --- コマンド型 ---
+export type InsertJobCommand = {
+  type: "InsertJob";
+  payload: InsertJobRequestBody;
+};
+export type FindJobByNumberCommand = {
+  type: "FindJobByNumber";
+  jobNumber: string;
+};
+export type FindJobsCommand = {
+  type: "FindJobs";
+  options: {
     cursor?: { jobId: number };
     limit: number;
     filter: { companyName?: string };
-  }) => Promise<{
+  };
+};
+export type CheckJobExistsCommand = {
+  type: "CheckJobExists";
+  jobNumber: string;
+};
+
+export type JobStoreCommand =
+  | InsertJobCommand
+  | FindJobByNumberCommand
+  | FindJobsCommand
+  | CheckJobExistsCommand;
+
+// --- コマンドtypeごとのoutput型マッピング ---
+export type SearchFilter = { companyName?: string };
+export interface CommandOutputMap {
+  InsertJob: { jobId: number };
+  FindJobByNumber: { job: Job | null };
+  FindJobs: {
     jobs: Job[];
     cursor: { jobId: number };
     meta: { totalCount: number; filter: SearchFilter };
-  }>;
-  checkJobExists: (jobNumber: string) => Promise<boolean>;
+  };
+  CheckJobExists: { exists: boolean };
+}
+
+// --- typeからoutput型を推論 ---
+export type CommandOutput<T extends JobStoreCommand> = T extends {
+  type: infer U;
+}
+  ? U extends keyof CommandOutputMap
+    ? CommandOutputMap[U]
+    : never
+  : never;
+
+// --- コマンドパターンなDBクライアント ---
+export type JobStoreDBClient = {
+  execute: <T extends JobStoreCommand>(cmd: T) => Promise<CommandOutput<T>>;
 };


### PR DESCRIPTION
従来のインターフェースベースのDBクライアント設計では、
behaviorの粒度を常に意識しながら実装する必要があり、
新機能追加時の設計負荷が高くなっていた。

コマンドパターンの導入により以下を実現：
- 単一のexecute()メソッドによる統一されたインターフェース
- コマンド型による操作の明確な定義（InsertJob, FindJobByNumber, FindJobs, CheckJobExists）
- CommandOutputMapによる型安全な戻り値の保証
- behaviorの粒度を気にせず新しい操作を追加可能な設計

技術的課題：
- 型推論の限界により、switch文内でas CommandOutput<T>の型キャストが必要
- より良い型安全な実装方法があるかもしれないが、現状では妥協策として採用

この変更により、機能追加時の設計負荷を軽減し、
開発効率と保守性を向上させる。